### PR TITLE
Add NOT_STARTED state

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ there have been two consecutive read or write failures, the status goes to ERROR
 
 Several parameters can be specified using environment variables:
 
-| Variable              | Default            | Description                               |
-|-----------------------|--------------------|-------------------------------------------|
-| `HEALTH_CHECK_TOPIC`  | `KafkaHealthCheck` | Topic to use for health check read/writes |
-| `BOOT_STRAP_SERVERS`  |`localhost`         | kafka brokers                             |
-| `GROUP_ID`            |`kafka_watcher`     | Group Id for Consumer                     |
-| `PROMETHEUS_ENDPOINT` | `0.0.0.0:8080`     | Endpoint for Prometheus metrics           |
-| `WATCHER_PERIOD`      |`600`               | How often to do a read/write cycle        |
-| `WATCHER_TIMEOUT`     |`60`                | How long to wait for message read         |
+| Variable              | Default              | Description                               |
+|-----------------------|----------------------|-------------------------------------------|
+| `HEALTH_CHECK_TOPIC`  | `kafka-health-check` | Topic to use for health check read/writes |
+| `BOOT_STRAP_SERVERS`  |`localhost`           | kafka brokers                             |
+| `GROUP_ID`            |`kafka_watcher`       | Group Id for Consumer                     |
+| `PROMETHEUS_ENDPOINT` | `0.0.0.0:8080`       | Endpoint for Prometheus metrics           |
+| `WATCHER_PERIOD`      |`600`                 | How often to do a read/write cycle        |
+| `WATCHER_TIMEOUT`     |`60`                  | How long to wait for message read         |
 
 ## Metrics
 
@@ -42,7 +42,7 @@ Several parameters can be specified using environment variables:
 | `kafka_max_round_trip_time`   | `gauge`   | Maximum Round Trip Time in seconds                |
 | `kafka_min_round_trip_time`   | `gauge`   | Minimum Round Trip Time in seconds                |
 | `kafka_read_failure_count`    | `counter` | Number of failures reading messages               |
-| `kafka_watcher_status`        | `gauge`   | Status of watcher, 0 = OK, 1 = WARNING, 2 = ERROR |
+| `kafka_watcher_status`        | `gauge`   | Status of watcher: -1 = NOT_STARTED, 0 = OK, 1 = WARNING, 2 = ERROR |
 | `kafka_write_failure_count`   | `counter` | Number of failures writing messages               |
 
 ## Install (using Docker)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8b7321a2ac92c5e276811c6aaa5c65128cb3f67fbf2927a6094d17aaccadb330
-updated: 2017-11-14T10:20:16.793842067-07:00
+hash: 5b6ad28649a538ff6abbee464eabd8843c31cd7a440641ea8db7c2817d8c9138
+updated: 2017-11-15T15:41:33.751719937-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -11,10 +11,6 @@ imports:
   version: f696f02dcbb04d95b103c5b848bb15f749a996f7
   subpackages:
   - kafka
-- name: github.com/craigbr/monasca-watchers
-  version: 2031f5a4acb570035b52eec17706d3fc7cb0e876
-  subpackages:
-  - watcher
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/golang/protobuf

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.hpe.com/UNCLE/kafka-watcher
+package: github.com/monasca/monasca-watchers
 import:
 - package: github.hpe.com/kronos/kelog
 - package: github.com/confluentinc/confluent-kafka-go

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -104,6 +104,7 @@ func TestSimple(t *testing.T) {
 	testBroker := createTestBroker(false, t)
 	watcher := CreateWatcher(testBroker, time.Duration(1)*time.Second, 1, twoHundredMilliseconds,
 		"TestSimple")
+	assert.Equal(t, Status(NOT_STARTED), watcher.Status, "Initial watcher.status")
 	watcher.Start()
 
 	testOneWriteRead(testBroker, watcher)


### PR DESCRIPTION
Add retries on initializing connections to Kafka to handle kafka
not being completely up and health check topic not created when
the watcher starts

Start Prometheus endpoint earlier so NOT_STARTED is available

Switch topic name to same form as other monasca topics

Fix import path