### PR TITLE
Fix InfluxDB read call

### DIFF
--- a/main/influxdb_watcher.go
+++ b/main/influxdb_watcher.go
@@ -89,7 +89,7 @@ func (broker *InfluxdbBroker) WriteMessage(byteMessage []byte) error {
 
 // ReadMessage query InfluxDB for latest measurement
 func (broker *InfluxdbBroker) ReadMessage(timeout time.Duration) (*[]byte, error) {
-	cmd := "SELECT \"message\",\"timestamp\" FROM \"watcher.influxdb\" limit 3"
+	cmd := "SELECT \"message\",\"timestamp\" FROM \"watcher.influxdb\" order by desc limit 3"
 	ch := make(chan []client.Result)
 	cherr := make(chan error)
 	go queryDB(broker, cmd, ch, cherr)
@@ -110,6 +110,7 @@ func (broker *InfluxdbBroker) ReadMessage(timeout time.Duration) (*[]byte, error
 					}
 				}
 			}
+			return nil, fmt.Errorf("Messages read do not match any sent recently by this watcher")
 		case err := <-cherr:
 			return nil, err
 		case <-time.After(timeout):


### PR DESCRIPTION
The InfluxDB call gets the first three metrics in the system instead of the latest three. Adding an order by desc fixes this
```
> SELECT "message", "timestamp" FROM "watcher.influxdb" order by desc limit 3
name: watcher.influxdb
time                message                                                                               timestamp
----                -------                                                                               ---------
1519847919000000000 {"UUID":"2018-02-28T18:30:38.373417954Z","SentTime":"2018-02-28T19:58:39.551742075Z"} 2018-02-28T19:58:39.551855807Z
1519847815000000000 {"UUID":"2018-02-28T19:56:55.655413703Z","SentTime":"2018-02-28T19:56:55.655529784Z"} 2018-02-28T19:56:55.655717634Z
1519847771000000000 {"UUID":"2018-02-28T19:56:11.17161348Z","SentTime":"2018-02-28T19:56:11.171667121Z"}  2018-02-28T19:56:11.171781602Z
> SELECT "message", "timestamp" FROM "watcher.influxdb" limit 3
name: watcher.influxdb
time                message                                                                               timestamp
----                -------                                                                               ---------
1517940971000000000 {"UUID":"2018-02-06T18:16:11.918682934Z","SentTime":"2018-02-06T18:16:11.918697948Z"} 2018-02-06T18:16:11.91883756Z
1517941571000000000 {"UUID":"2018-02-06T18:16:11.918682934Z","SentTime":"2018-02-06T18:26:11.956124914Z"} 2018-02-06T18:26:11.956210588Z
1518556277000000000 {"UUID":"2018-02-13T21:11:17.251276704Z","SentTime":"2018-02-13T21:11:17.251281339Z"} 2018-02-13T21:11:17.251508996Z
```
There was also a for loop around the select statement that was totally unnecessary because all cases should return either a value or an error
